### PR TITLE
Updated XML catalog for GENC codes to use the right codespace for numeric code list

### DIFF
--- a/xsd/codes/genc.xsd
+++ b/xsd/codes/genc.xsd
@@ -11,6 +11,7 @@
   <xs:annotation>
     <xs:documentation>Geopolitical Entities, Names, and Codes (GENC) country and country subdivision codes.  This is a profile of ISO 3166 that addresses unique U.S. government requirements.</xs:documentation>
     <xs:appinfo>
+      <appinfo:LocalTerm term="Alpha2" definition="Two-letter"/>
       <appinfo:LocalTerm term="Alpha3" definition="Three-letter"/>
     </xs:appinfo>
   </xs:annotation>
@@ -1415,7 +1416,7 @@
     <xs:annotation>
       <xs:documentation>A data type for country codes.</xs:documentation>
       <xs:appinfo>
-        <clsa:SimpleCodeListBinding codeListURI="http://api.nsgreg.nga.mil/geo-political/GENC/2/3-11" constrainingIndicator="false"/>
+        <clsa:SimpleCodeListBinding codeListURI="http://api.nsgreg.nga.mil/geo-political/GENC/3/3-11" constrainingIndicator="false"/>
       </xs:appinfo>
     </xs:annotation>
     <xs:restriction base="xs:token">
@@ -2835,7 +2836,7 @@
     <xs:annotation>
       <xs:documentation>A data type for country codes.</xs:documentation>
       <xs:appinfo>
-        <clsa:SimpleCodeListBinding codeListURI="http://api.nsgreg.nga.mil/geo-political/GENC/2/3-11" constrainingIndicator="false"/>
+        <clsa:SimpleCodeListBinding codeListURI="http://api.nsgreg.nga.mil/geo-political/GENC/n/3-11" constrainingIndicator="false"/>
       </xs:appinfo>
     </xs:annotation>
     <xs:restriction base="xs:token">

--- a/xsd/codes/genc/xml-catalog.xml
+++ b/xsd/codes/genc/xml-catalog.xml
@@ -5,8 +5,8 @@
   <uri name="urn:us:gov:dod:nga:def:geo-political:GENC:2:3-11" uri="genc_geo-political_3-11_char2.csv"/>
   <uri name="http://api.nsgreg.nga.mil/geo-political/GENC/3/3-11" uri="genc_geo-political_3-11_char3.csv"/>
   <uri name="urn:us:gov:dod:nga:def:geo-political:GENC:3:3-11" uri="genc_geo-political_3-11_char3.csv"/>
-  <uri name="http://api.nsgreg.nga.mil/geo-political/GENC/3/3-11" uri="genc_geo-political_3-11_numeric.csv"/>
-  <uri name="urn:us:gov:dod:nga:def:geo-political:GENC:3:3-11" uri="genc_geo-political_3-11_numeric.csv"/>
+  <uri name="http://api.nsgreg.nga.mil/geo-political/GENC/n/3-11" uri="genc_geo-political_3-11_numeric.csv"/>
+  <uri name="urn:us:gov:dod:nga:def:geo-political:GENC:n:3-11" uri="genc_geo-political_3-11_numeric.csv"/>
   <uri name="http://api.nsgreg.nga.mil/geo-division/GENC/6/3-11" uri="genc_geo-division_3-11_char6.csv"/>
   <uri name="urn:us:gov:dod:nga:def:geo-division:GENC:6:3-11" uri="genc_geo-division_3-11_char6.csv"/>
 </catalog>


### PR DESCRIPTION
In the XML catalog for GENC code lists, 5.0rc3 had the wrong code list URI for the numeric code list. This pull request fixes the XML catalog to use the right URI for that list.